### PR TITLE
Remove programatic height

### DIFF
--- a/dnotebook/src/public/javascripts/utils.js
+++ b/dnotebook/src/public/javascripts/utils.js
@@ -388,7 +388,7 @@
      */
     function update_text_box_size() {
         $('textarea').each(function () {
-            this.setAttribute('style', 'height:' + (this.scrollHeight) + 'px;overflow-y:hidden;');
+            this.setAttribute('style', 'overflow-y:hidden;');
         }).on('input', function () {
             this.style.height = 'auto';
             this.style.height = (this.scrollHeight) + 'px';


### PR DESCRIPTION
When you upload a JSON file the text height is zero, so this sets textarea heights to zero.

While it works great while live editing, a loaded JSON file when edited gets set to zero.

<img width="871" alt="Screen Shot 2020-12-13 at 10 09 59 PM" src="https://user-images.githubusercontent.com/997157/102039848-a81d2780-3d90-11eb-843d-1482090e73f7.png">

